### PR TITLE
Change the location of `local.properties`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ steps:
       GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 ```
 
-For the build in your local, you can store the token in the `local.properties` file at the root of your project:
+For the build in your local, you can store the token in the `local.properties` file at the root of your project.
 
 ## How to develop
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ steps:
       GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 ```
 
-For the build in your local, you can store the token in the `app/src/main/resources/local.properties` file.
+For the build in your local, you can store the token in the `local.properties` file at the root of your project:
 
 ## How to develop
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Apply the plugin to your build script, import the extension method and use it as
 ```kotlin
 import jp.henry.gradle.repository.packages
 plugins {
-    id("jp.henry.maven.repository") version "1.0.1"
+    id("jp.henry.maven.repository") version "2.0.0"
 }
 
 repositories {

--- a/plugin/src/main/kotlin/jp/henry/gradle/repository/HenryMavenRepositoryPlugin.kt
+++ b/plugin/src/main/kotlin/jp/henry/gradle/repository/HenryMavenRepositoryPlugin.kt
@@ -10,7 +10,7 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.slf4j.Logger
 
-const val PROPERTIES_FILE_PATH = "app/src/main/resources/local.properties"
+const val PROPERTIES_FILE_PATH = "local.properties"
 
 data class Credential(val user: String?, val pass: String?)
 


### PR DESCRIPTION
## Why / 背景

- GitHub Packages の認証用に `local.properties` を `app/src/main/resources` に配置する必要があったが、monorepo 化に伴い、この場所が不適切/不自然になった

## What / 変更内容

- `local.properties` を読みに行く場所を変更
  - `app/src/main/resources` -> （プロジェクトルート）

## Checklist / 自己チェック

レビュワーをアサインする前にチェックを付けましょう。

- [ ] [レビュー依頼側のチェックリスト](https://www.notion.so/henry-inc/Code-review-55c4fcd2587444ca987480a813a7b93a) の項目を確認した
- [ ] 実装の意図や、仕様や実装で不安な点をセルフレビューのコメントなどで補足した
- [ ] 既存のデータに影響ないことを確認した
- [ ] QA依頼を作成した: (ここにURLを記載)
- [ ] 動作を確認した
